### PR TITLE
[FIX] 로그인 이슈 해결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,6 +17,7 @@ android {
 val properties = Properties()
 properties.load(project.rootProject.file("local.properties").inputStream())
 val tMapApiKey = properties.getProperty("tmap.api")
+val kakaoManifestKey = properties.getProperty("kakao.manifest")
 val kakaoKey = properties.getProperty("kakao")
 val baseUrl = properties.getProperty("base.url")
 
@@ -36,7 +37,7 @@ android {
         buildConfigField("String", "TMAP_API_KEY", tMapApiKey)
         manifestPlaceholders["TMAP_API_KEY"] = tMapApiKey
         buildConfigField("String", "KAKAO_KEY", kakaoKey)
-        manifestPlaceholders["KAKAO_KEY"] = kakaoKey
+        manifestPlaceholders["KAKAO_KEY"] = kakaoManifestKey
         buildConfigField("String", "BASE_URL", baseUrl)
         manifestPlaceholders["BASE_URL"] = baseUrl
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,7 @@ properties.load(project.rootProject.file("local.properties").inputStream())
 val tMapApiKey = properties.getProperty("tmap.api")
 val kakaoManifestKey = properties.getProperty("kakao.manifest")
 val kakaoKey = properties.getProperty("kakao")
+val googleWebClientId = properties.getProperty("google.web.client.id")
 val baseUrl = properties.getProperty("base.url")
 
 android {
@@ -40,6 +41,7 @@ android {
         manifestPlaceholders["KAKAO_KEY"] = kakaoManifestKey
         buildConfigField("String", "BASE_URL", baseUrl)
         manifestPlaceholders["BASE_URL"] = baseUrl
+        buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", googleWebClientId)
     }
 
     buildTypes {

--- a/app/src/main/java/com/charo/android/presentation/ui/signin/SocialSignInActivity.kt
+++ b/app/src/main/java/com/charo/android/presentation/ui/signin/SocialSignInActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.Observer
+import com.charo.android.BuildConfig
 import com.charo.android.R
 import com.charo.android.data.model.request.signin.RequestSocialData
 import com.charo.android.databinding.ActivitySocialSignInBinding
@@ -244,7 +245,7 @@ class SocialSignInActivity() :
 
     private fun initGoogleLogin() {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(getString(R.string.default_web_client_id))
+            .requestIdToken(BuildConfig.GOOGLE_WEB_CLIENT_ID)
             .requestEmail()
             .build()
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,5 +3,6 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">charo-server.o-r.kr</domain>
         <domain includeSubdomains="true">52.79.108.141</domain>
+        <domain includeSubdomains="true">3.35.17.144</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
소셜 로그인이 되지 않던 현상을 해결했습니다.

[디버그 빌드]
1. 카카오 로그인
    - 카카오 앱 키를 String 형태로 Manifest에서 사용할 경우 로그인이 되지 않습니다.
2. 구글 로그인
    - 제 SHA-1이 등록되어 있지 않던 것을 확인했고, 추가로 모종의 이유로 Google Web Client Id가 누락된 것을 확인했습니다.

[릴리즈 빌드]
1. 카카오 로그인
    - 로그를 확인할 수 없었는데, 카카오 릴리즈 키 해시가 제대로 등록됐는지 확인이 필요합니다.
2. 구글 로그인
    - 정상 동작합니다.